### PR TITLE
Removed unused App.config from project

### DIFF
--- a/Nexmo.Api.Test.Unit/Nexmo.Api.Test.Unit.csproj
+++ b/Nexmo.Api.Test.Unit/Nexmo.Api.Test.Unit.csproj
@@ -18,10 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Nexmo.Api\Nexmo.Api.csproj" />
 
     <!--<Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework">


### PR DESCRIPTION
According to the changelog, in the version 2.0.0-rc1 (2016-10-16), the configuration was moved from app.config to settings.json.
But, in the Api.Test.Unit project it's still there, causing build "not found file" error.