### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ either including them with your project's NuGet dependencies or manually referen
 Targeted frameworks:
 --------------
 
-* 4.5.2
 * 4.6, 4.6.1, 4.6.2
 * .NET Standard 1.6, 2.0
 * ASP.NET Core 2.0


### PR DESCRIPTION
As per suggestion from Support https://nexmo.slack.com/archives/C04HCA4BF/p1540325941000100

Remove 4.5.2 from Targeted frameworks to avoid TLS 1.0./1.1 issues

I know that technically the lib will still support 4.5.2 but is there a very good reason to still advertise that or would telling people to use >4.6 be ok, this should then help to reduce TLS issues.