### PR TITLE
Add URI query deserilization support for models

### DIFF
--- a/Nexmo.Api/Account.cs
+++ b/Nexmo.Api/Account.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Nexmo.Api.Request;
 
@@ -50,14 +51,19 @@ namespace Nexmo.Api
         public class Settings
         {
             [JsonProperty("api-secret")]
+            [FromQuery(Name = "api-secret")]
             public string apiSecret { get; set; }
             [JsonProperty("mo-callback-url")]
+            [FromQuery(Name = "mo-callback-url")]
             public string moCallbackUrl { get; set; }
             [JsonProperty("dr-callback-url")]
+            [FromQuery(Name = "dr-callback-url")]
             public string drCallbackUrl { get; set; }
             [JsonProperty("max-outbound-request")]
+            [FromQuery(Name = "max-outbound-request")]
             public decimal maxOutboundRequest { get; set; }
             [JsonProperty("max-inbound-request")]
+            [FromQuery(Name = "max-inbound-request")]
             public decimal maxInboundRequest { get; set; }
         }
 
@@ -84,7 +90,7 @@ namespace Nexmo.Api
         public class NumbersResponse
         {
             public int count { get; set; }
-            public List<Number> numbers { get; set; } 
+            public List<Number> numbers { get; set; }
         }
 
         public class Number

--- a/Nexmo.Api/ApiSecret.cs
+++ b/Nexmo.Api/ApiSecret.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Nexmo.Api.Request;
 
@@ -11,6 +12,7 @@ namespace Nexmo.Api
         public class SecretList
         {
             [JsonProperty("secrets")]
+            [FromQuery(Name = "secrets")]
             public List<Secret> Secrets { get; set; }
         }
 
@@ -18,14 +20,17 @@ namespace Nexmo.Api
         {
             public HALLinks _links { get; set; }
             [JsonProperty("id")]
+            [FromQuery(Name = "id")]
             public string Id { get; set; }
             [JsonProperty("created_at")]
-            public DateTime? CreatedAt { get; set;  }
+            [FromQuery(Name = "created_at")]
+            public DateTime? CreatedAt { get; set; }
         }
 
         public class SecretRequest
         {
             [JsonProperty("secret")]
+            [FromQuery(Name = "secret")]
             public string Secret { get; set; }
         }
 

--- a/Nexmo.Api/Nexmo.Api.csproj
+++ b/Nexmo.Api/Nexmo.Api.csproj
@@ -42,6 +42,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.2.*" />

--- a/Nexmo.Api/Nexmo.Api.nuspec
+++ b/Nexmo.Api/Nexmo.Api.nuspec
@@ -19,6 +19,7 @@
 		<dependencies>
 			<group targetFramework="net452">
 				<!-- Default dependencies -->
+				<dependency id="Microsoft.AspNetCore.Mvc.Core" version="1.1.8" />
 				<dependency id="Microsoft.Extensions.Configuration" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Json" version="1.0.2" />
@@ -30,6 +31,7 @@
 			</group>
 			<group targetFramework="net46">
 				<!-- Default dependencies -->
+				<dependency id="Microsoft.AspNetCore.Mvc.Core" version="1.1.8" />
 				<dependency id="Microsoft.Extensions.Configuration" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Json" version="1.0.2" />
@@ -41,6 +43,7 @@
 			</group>
 			<group targetFramework="net461">
 				<!-- Default dependencies -->
+				<dependency id="Microsoft.AspNetCore.Mvc.Core" version="1.1.8" />
 				<dependency id="Microsoft.Extensions.Configuration" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Json" version="1.0.2" />
@@ -52,6 +55,7 @@
 			</group>
 			<group targetFramework="net462">
 				<!-- Default dependencies -->
+				<dependency id="Microsoft.AspNetCore.Mvc.Core" version="1.1.8" />
 				<dependency id="Microsoft.Extensions.Configuration" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Json" version="1.0.2" />
@@ -63,6 +67,7 @@
 			</group>
 			<group targetFramework="net471">
 				<!-- Default dependencies -->
+				<dependency id="Microsoft.AspNetCore.Mvc.Core" version="1.1.8" />
 				<dependency id="Microsoft.Extensions.Configuration" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Json" version="1.0.2" />
@@ -78,6 +83,7 @@
 			<group targetFramework="netstandard1.6">
 				<!-- (copied from above as NuGet doesn't cascade deps) -->
 				<!-- Default dependencies -->
+				<dependency id="Microsoft.AspNetCore.Mvc.Core" version="1.1.8" />
 				<dependency id="Microsoft.Extensions.Configuration" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Json" version="1.0.2" />
@@ -96,6 +102,7 @@
 			<group targetFramework="netstandard2.0">
 				<!-- (copied from above as NuGet doesn't cascade deps) -->
 				<!-- Default dependencies -->
+				<dependency id="Microsoft.AspNetCore.Mvc.Core" version="1.1.8" />
 				<dependency id="Microsoft.Extensions.Configuration" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.2" />
 				<dependency id="Microsoft.Extensions.Configuration.Json" version="1.0.2" />

--- a/Nexmo.Api/NumberInsight.cs
+++ b/Nexmo.Api/NumberInsight.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Nexmo.Api.Request;
 
@@ -13,21 +14,25 @@ namespace Nexmo.Api
             /// Required. A single phone number that you need insight about in national or international format. The number may include any or all of the following: white space, -, +, (, ).
             /// </summary>
             [JsonProperty(PropertyName = "number")]
+            [FromQuery(Name = "number")]
             public string Number { get; set; }
             /// <summary>
             /// Optional. If a number does not have a country code or is uncertain, set the two-character country code. This code must be in ISO 3166-1 alpha-2 format and in upper case. For example, GB or US. If you set country and number is already in E.164  format, country must match the country code in number.
             /// </summary>
             [JsonProperty(PropertyName = "country")]
+            [FromQuery(Name = "country")]
             public string Country { get; set; }
             /// <summary>
             /// Optional. Indicates if the name of the person who owns the phone number should be looked up and returned in the response. Set to true to receive phone number owner name in the response. This features is available for US numbers only and incurs an additional charge. Default value is false.
             /// </summary>
             [JsonProperty(PropertyName = "cnam")]
+            [FromQuery(Name = "cnam")]
             public string CallerIDName { get; set; }
             /// <summary>
             /// Optional. The IP address of the user. If supplied, we will compare this to the country the user's phone is located in and return an error if it does not match.
             /// </summary>
             [JsonProperty(PropertyName = "ip")]
+            [FromQuery(Name = "ip")]
             public string IPAddress { get; set; }
         }
 
@@ -37,6 +42,7 @@ namespace Nexmo.Api
             /// Webhook URL used to send NI response to
             /// </summary>
             [JsonProperty(PropertyName = "callback")]
+            [FromQuery(Name = "callback")]
             public string Callback { get; set; }
         }
 
@@ -46,46 +52,56 @@ namespace Nexmo.Api
             /// The status code and a description about your request. When status is 0 or 1,status_message is returned. For all other values,error_text. 
             /// </summary>
             [JsonProperty(PropertyName = "status")]
+            [FromQuery(Name = "status")]
             public string Status { get; set; }
             [JsonProperty(PropertyName = "status_message")]
+            [FromQuery(Name = "status_message")]
             public string StatusMessage { get; set; }
             [JsonProperty(PropertyName = "error_text")]
+            [FromQuery(Name = "error_text")]
             public string ErrorText { get; set; }
 
             /// <summary>
             /// The unique identifier for your request. This is a alphanumeric string up to 40 characters.
             /// </summary>
             [JsonProperty(PropertyName = "request_id")]
+            [FromQuery(Name = "request_id")]
             public string RequestId { get; set; }
             /// <summary>
             /// The number in your request in International format.
             /// </summary>
             [JsonProperty(PropertyName = "international_format_number")]
+            [FromQuery(Name = "international_format_number")]
             public string InternationalFormatNumber { get; set; }
             /// <summary>
             /// Looked up Number in format used by the country the number belongs to.
             /// </summary>
             [JsonProperty(PropertyName = "national_format_number")]
+            [FromQuery(Name = "national_format_number")]
             public string NationalFormatNumber { get; set; }
             /// <summary>
             /// Two character country code for number. This is in ISO 3166-1 alpha-2 format.
             /// </summary>
             [JsonProperty(PropertyName = "country_code")]
+            [FromQuery(Name = "country_code")]
             public string CountryCode { get; set; }
             /// <summary>
             /// Two character country code for number. This is in ISO 3166-1 alpha-3 format.
             /// </summary>
             [JsonProperty(PropertyName = "country_code_iso3")]
+            [FromQuery(Name = "country_code_iso3")]
             public string CountryCodeIso3 { get; set; }
             /// <summary>
             /// The full name of the country that number is registered in.
             /// </summary>
             [JsonProperty(PropertyName = "country_name")]
+            [FromQuery(Name = "country_name")]
             public string CountryName { get; set; }
             /// <summary>
             /// The numeric prefix for the country that number is registered in.
             /// </summary>
             [JsonProperty(PropertyName = "country_prefix")]
+            [FromQuery(Name = "country_prefix")]
             public string CountryPrefix { get; set; }
         }
 
@@ -95,21 +111,25 @@ namespace Nexmo.Api
             /// The MCCMNC for the carrier *number* is associated with.Unreal numbers are marked as 'unknown' and the request is rejected altogether if the number is impossible as per E.164 guidelines.
             /// </summary>
             [JsonProperty(PropertyName = "network_code")]
+            [FromQuery(Name = "network_code")]
             public string NetworkCode { get; set; }
             /// <summary>
             /// The full name of the carrier that *number* is associated with.
             /// </summary>
             [JsonProperty(PropertyName = "name")]
+            [FromQuery(Name = "name")]
             public string Name { get; set; }
             /// <summary>
             /// The country that *number* is associated with. This is in ISO 3166-1 alpha-2 format.
             /// </summary>
             [JsonProperty(PropertyName = "country")]
+            [FromQuery(Name = "country")]
             public string Country { get; set; }
             /// <summary>
             /// The type of network that *number* is associated with. For example mobile, landline, virtual, premium, toll-free.
             /// </summary>
             [JsonProperty(PropertyName = "network_type")]
+            [FromQuery(Name = "network_type")]
             public string NetworkType { get; set; }
         }
 
@@ -119,51 +139,61 @@ namespace Nexmo.Api
             /// The amount in EUR charged to your account.
             /// </summary>
             [JsonProperty(PropertyName = "request_price")]
+            [FromQuery(Name = "request_price")]
             public string RequestPrice { get; set; }
             /// <summary>
             /// If there is an internal lookup error, the refund_price will reflect the lookup price. If cnam is requested for a non-US number the refund_price will reflect the cnam price. If both of these conditions occur, refund_price is the sum of the lookup price and cnam price.
             /// </summary>
             [JsonProperty(PropertyName = "refund_price")]
+            [FromQuery(Name = "refund_price")]
             public string RefundPrice { get; set; }
             /// <summary>
             /// Your account balance in EUR after this request.
             /// </summary>
             [JsonProperty(PropertyName = "remaining_balance")]
+            [FromQuery(Name = "remaining_balance")]
             public string RemainingBalance { get; set; }
             /// <summary>
             /// If the user has changed carrier for number. Possible values are: unknown, ported, not_ported, assumed_not_ported, assumed_ported. The assumed status means that the information supplier has replied to the request but has not said explicitly that the number is ported.
             /// </summary>
             [JsonProperty(PropertyName = "ported")]
+            [FromQuery(Name = "ported")]
             public string PortedStatus { get; set; }
             /// <summary>
             /// Information about the network number is currently connected to.
             /// </summary>
             [JsonProperty(PropertyName = "current_carrier")]
+            [FromQuery(Name = "current_carrier")]
             public CarrierInfo CurrentCarrier { get; set; }
             /// <summary>
             /// Information about the network number was initially connected to
             /// </summary>
             [JsonProperty(PropertyName = "original_carrier")]
+            [FromQuery(Name = "original_carrier")]
             public CarrierInfo OriginalCarrier { get; set; }
             /// <summary>
             /// Full name of the person who owns the phone number.unknown if this information is not available. This parameter is only present if cnam had a value of true within the request.
             /// </summary>
             [JsonProperty(PropertyName = "caller_name")]
+            [FromQuery(Name = "caller_name")]
             public string CallerName { get; set; }
             /// <summary>
             /// First name of the person who owns the phone number if the owner is an individual. This parameter is only present if cnam had a value of true within the request.
             /// </summary>
             [JsonProperty(PropertyName = "first_name")]
+            [FromQuery(Name = "first_name")]
             public string FirstName { get; set; }
             /// <summary>
             /// Last name of the person who owns the phone number if the owner is an individual. This parameter is only present if cnam had a value of true within the request.
             /// </summary>
             [JsonProperty(PropertyName = "last_name")]
+            [FromQuery(Name = "last_name")]
             public string LastName { get; set; }
             /// <summary>
             /// The value will be business if the owner of a phone number is a business. If the owner is an individual the value will be consumer. The value will be unknown if this information is not available. This parameter is only present if cnam had a value of true within the request.
             /// </summary>
             [JsonProperty(PropertyName = "caller_type")]
+            [FromQuery(Name = "caller_type")]
             public string CallerType { get; set; }
         }
 
@@ -173,24 +203,29 @@ namespace Nexmo.Api
             /// Shows if all information about a phone number has been returned.
             /// </summary>
             [JsonProperty(PropertyName = "lookup_outcome")]
+            [FromQuery(Name = "lookup_outcome")]
             public int LookupOutcome { get; set; }
             [JsonProperty(PropertyName = "lookup_outcome_message")]
+            [FromQuery(Name = "lookup_outcome_message")]
             public string LookupOutcomeMessage { get; set; }
 
             /// <summary>
             /// Does number exist. Possible values are unknown, valid, not_valid. This is applicable to mobile numbers only.
             /// </summary>
             [JsonProperty(PropertyName = "valid_number")]
+            [FromQuery(Name = "valid_number")]
             public string NumberValidity { get; set; }
             /// <summary>
             /// Can you call number now. Possible values are: unknown, reachable, undeliverable, absent, bad_number, blacklisted. This is applicable to mobile numbers only.
             /// </summary>
             [JsonProperty(PropertyName = "reachable")]
+            [FromQuery(Name = "reachable")]
             public string NumberReachability { get; set; }
             /// <summary>
             /// Information about the roaming status for number. Possible values. This is applicable to mobile numbers only.
             /// </summary>
             [JsonProperty(PropertyName = "roaming")]
+            [FromQuery(Name = "roaming")]
             public Roaming RoamingInformation { get; set; }
             /// <summary>
             /// The ip address you specified in the request. This field is blank if you did not specify ip.
@@ -210,15 +245,15 @@ namespace Nexmo.Api
             public string ip_country { get; set; }
         }
 
-    public class Roaming
-    {
-        public string status { get; set; }
-        public string roaming_country_code { get; set; }
-        public string roaming_network_code { get; set; }
-        public string roaming_network_name { get; set; }
-    }
+        public class Roaming
+        {
+            public string status { get; set; }
+            public string roaming_country_code { get; set; }
+            public string roaming_network_code { get; set; }
+            public string roaming_network_name { get; set; }
+        }
 
-    public class NumberInsightAsyncRequestResponse
+        public class NumberInsightAsyncRequestResponse
         {
             public string request_id { get; set; }
             public string number { get; set; }

--- a/Nexmo.Api/Redact.cs
+++ b/Nexmo.Api/Redact.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 using Nexmo.Api.Request;
 using System;
 using System.Collections.Generic;
@@ -16,21 +17,24 @@ namespace Nexmo.Api
             /// The transaction ID to redact
             /// </summary>
             [JsonProperty("id")]
+            [FromQuery(Name = "id")]
             public string Id { get; set; }
             /// <summary>
             /// Product name that the ID provided relates to
             /// Must be one of: sms, voice, number-insight, verify, verify-sdk, message or workflow
             /// </summary>
             [JsonProperty("product")]
+            [FromQuery(Name = "product")]
             public string Product { get; set; }
             /// <summary>
             /// Required if redacting SMS data
             /// Must be one of: inbound or outbound
             /// </summary>
             [JsonProperty("type")]
+            [FromQuery(Name = "type")]
             public string Type { get; set; }
 
-            public RedactRequest (string id, string product)
+            public RedactRequest(string id, string product)
             {
                 Id = id;
                 Product = product;

--- a/Nexmo.Api/ResponseBase.cs
+++ b/Nexmo.Api/ResponseBase.cs
@@ -1,12 +1,15 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 
 namespace Nexmo.Api
 {
     public class ResponseBase
     {
         [JsonProperty("error-code")]
+        [FromQuery(Name = "error-code")]
         public string ErrorCode { get; set; }
         [JsonProperty("error-code-label")]
+        [FromQuery(Name = "error-code-label")]
         public string ErrorCodeLabel { get; set; }
     }
 }

--- a/Nexmo.Api/SMS.cs
+++ b/Nexmo.Api/SMS.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Nexmo.Api.Request;
 
@@ -126,6 +127,7 @@ namespace Nexmo.Api
             ///Set the callback parameter.
             /// </summary>
             [JsonProperty("status-report-req")]
+            [FromQuery(Name = "status-report-req")]
             public string status_report_req { get; set; }
             /// <summary>
             /// A business card in vCard. You must set the type parameter to vcard.
@@ -147,6 +149,7 @@ namespace Nexmo.Api
             /// Set to: 0 for Flash SMS, 1 - ME-specific, 2 - SIM / USIM specific, 3 - TE-specific See http://en.wikipedia.org/wiki/Data_Coding_Scheme  Note: Flash SMS is not fully support by all handsets and carriers.
             /// </summary>
             [JsonProperty("message-class")]
+            [FromQuery(Name = "message-class")]
             public string message_class { get; set; }
             /// <summary>
             /// Your custom Hex encoded User Data Header (UDH)  . For example, udh=06050415811581.
@@ -156,6 +159,7 @@ namespace Nexmo.Api
             /// 	The value in decimal format for the higher level protocol  to use for this SMS. For example, to send a binary SMS to the SIM Toolkit, this would be protocol-id=127. Ensure that the value of protocol-id is aligned with udh.
             /// </summary>
             [JsonProperty("protocol-id")]
+            [FromQuery(Name = "protocol-id")]
             public string protocol_id { get; set; }
             /// <summary>
             /// Hex encoded binary data. For example, body=0011223344556677.
@@ -177,12 +181,14 @@ namespace Nexmo.Api
             /// If enabled, you can include a 40 character maximum length string for internal reporting/analytics. You will need to email support@nexmo.com to get this functionality enabled on your account.
             /// </summary>
             [JsonProperty("client-ref")]
+            [FromQuery(Name = "client-ref")]
             public string client_ref { get; set; }
         }
 
         public class SMSResponse
         {
             [JsonProperty("message-count")]
+            [FromQuery(Name = "message-count")]
             public string message_count { get; set; }
             public System.Collections.Generic.List<SMSResponseDetail> messages { get; set; }
         }
@@ -197,6 +203,7 @@ namespace Nexmo.Api
             /// The ID of the SMS that was submitted (8 to 16 characters).
             /// </summary>
             [JsonProperty("message-id")]
+            [FromQuery(Name = "message-id")]
             public string message_id { get; set; }
             /// <summary>
             /// The phone number your request was sent to.
@@ -206,16 +213,19 @@ namespace Nexmo.Api
             /// The client-ref you set in your request.
             /// </summary>
             [JsonProperty("client-ref")]
+            [FromQuery(Name = "client-ref")]
             public string client_ref { get; set; }
             /// <summary>
             /// The remaining balance in your account. The value is in EUR.
             /// </summary>
             [JsonProperty("remaining-balance")]
+            [FromQuery(Name = "remaining-balance")]
             public string remaining_balance { get; set; }
             /// <summary>
             /// The price charged for your request. The value is in EUR.
             /// </summary>
             [JsonProperty("message-price")]
+            [FromQuery(Name = "message-price")]
             public string message_price { get; set; }
             /// <summary>
             /// The Mobile Country Code Mobile Network Code (MCCMNC) for the carrier of the recipient.
@@ -225,6 +235,7 @@ namespace Nexmo.Api
             /// If an error occurred, this explains what happened.
             /// </summary>
             [JsonProperty("error-text")]
+            [FromQuery(Name = "error-text")]
             public string error_text { get; set; }
         }
 
@@ -238,6 +249,7 @@ namespace Nexmo.Api
             /// The Mobile Country Code Mobile Network Code (MCCMNC) of the carrier this phone number is registered with.
             /// </summary>
             [JsonProperty("network-code")]
+            [FromQuery(Name = "network-code")]
             public string network_code { get; set; }
             /// <summary>
             /// The Nexmo ID for this message.
@@ -255,6 +267,7 @@ namespace Nexmo.Api
             /// If the status is not accepted, this key will have a value
             /// </summary>
             [JsonProperty("err-code")]
+            [FromQuery(Name = "err-code")]
             public string err_code { get; set; }
             /// <summary>
             /// How much it cost to send this message.
@@ -268,12 +281,14 @@ namespace Nexmo.Api
             /// The time at UTC±00:00 when Nexmo started to push this Delivery Receipt to your webhook endpoint. The message-timestamp is in the following format YYYY-MM-DD HH:MM:SS. For example, 2020-01-01 12:00:00.
             /// </summary>
             [JsonProperty("message-timestamp")]
+            [FromQuery(Name = "message-timestamp")]
             public DateTime message_timestamp { get; set; }
             /// <summary>
             /// The client-ref you set in the request.
             /// </summary>
             [JsonProperty("client-ref")]
-            public string client_ref { get; set; }            
+            [FromQuery(Name = "client-ref")]
+            public string client_ref { get; set; }
         }
 
         public class SMSInbound
@@ -301,6 +316,7 @@ namespace Nexmo.Api
             /// The time at UTC±00:00  that Nexmo started to push this inbound message to your webhook endpoint. The message-timestamp is in the following format YYYY-MM-DD HH:MM:SS. For example, 2020-01-01 12:00:00.
             /// </summary>
             [JsonProperty("message-timestamp")]
+            [FromQuery(Name = "message-timestamp")]
             public DateTime message_timestamp { get; set; }
             /// <summary>
             /// A unix timestamp representation of message-timestamp.
@@ -332,16 +348,19 @@ namespace Nexmo.Api
             /// The transaction reference. All parts of this message share this concat-ref.
             /// </summary>
             [JsonProperty("concat-ref")]
+            [FromQuery(Name = "concat-ref")]
             public string concat_ref { get; set; }
             /// <summary>
             /// The number of parts in this concatenated message.
             /// </summary>
             [JsonProperty("concat-total")]
+            [FromQuery(Name = "concat-total")]
             public string concat_total { get; set; }
             /// <summary>
             /// The number of this part in the message. Counting starts at 1.
             /// </summary>
             [JsonProperty("concat-part")]
+            [FromQuery(Name = "concat-part")]
             public string concat_part { get; set; }
 
             // For binary messages

--- a/Nexmo.Api/Search.cs
+++ b/Nexmo.Api/Search.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Nexmo.Api.Request;
 
@@ -9,7 +10,7 @@ namespace Nexmo.Api
         public class Messages<T> where T : MessageBase
         {
             public int count { get; set; }
-            public List<T> items { get; set; } 
+            public List<T> items { get; set; }
         }
 
         public class MessageBase
@@ -18,6 +19,7 @@ namespace Nexmo.Api
             /// Your API Key.
             /// </summary>
             [JsonProperty("account-id")]
+            [FromQuery(Name = "account-id")]
             public string accountId { get; set; }
             /// <summary>
             /// The sender ID the message was sent from. Could be a phone number or name.
@@ -35,16 +37,19 @@ namespace Nexmo.Api
             /// The date and time at UTC+0 when Platform received your request in the following format: YYYY-MM-DD HH:MM:SS.
             /// </summary>
             [JsonProperty("date-received")]
+            [FromQuery(Name = "date-received")]
             public string dateReceived { get; set; }
             /// <summary>
             /// Optional. Delivery receipt error code Ex: 4
             /// </summary>
             [JsonProperty("error-code")]
+            [FromQuery(Name = "error-code")]
             public string errorCode { get; set; }
             /// <summary>
             /// Optional. Delivery receipt error code label Ex: Call Barred
             /// </summary>
             [JsonProperty("error-code-label")]
+            [FromQuery(Name = "error-code-label")]
             public string errorCodeLabel { get; set; }
         }
 
@@ -58,6 +63,7 @@ namespace Nexmo.Api
             /// The id of the message you sent.
             /// </summary>
             [JsonProperty("message-id")]
+            [FromQuery(Name = "message-id")]
             public string messageId { get; set; }
             /// <summary>
             /// Optional. The MCCMNC for the carrier who delivered the message.
@@ -74,6 +80,7 @@ namespace Nexmo.Api
             /// The date and time at UTC+0 when Platform received the delivery receipt from the carrier who delivered the MT message. This parameter is in the following format YYYY-MM-DD HH:MM:SS
             /// </summary>
             [JsonProperty("date-closed")]
+            [FromQuery(Name = "date-closed")]
             public string dateClosed { get; set; }
             /// <summary>
             /// The overall latency between date-received and date-closed in milliseconds.
@@ -83,11 +90,13 @@ namespace Nexmo.Api
             /// The internal reference you set in the request.
             /// </summary>
             [JsonProperty("client-ref")]
+            [FromQuery(Name = "client-ref")]
             public string clientRef { get; set; }
             /// <summary>
             /// The status of message-id at date-closed.
             /// </summary>
             [JsonProperty("final-status")]
+            [FromQuery(Name = "final-status")]
             public string finalStatus { get; set; }
             /// <summary>
             /// A code that explains where the message is in the delivery process. If status is not delivered check error-code for more information. If status is accepted ignore the value of error-code
@@ -98,7 +107,7 @@ namespace Nexmo.Api
         public class SearchRequest
         {
             // Search by ids
-            
+
             /// <summary>
             /// Required. A list of message ids, up to 10 Ex: ids=00A0B0C0&ids=00A0B0C1&ids=00A0B0C2
             /// </summary>

--- a/Nexmo.Api/ShortCode.cs
+++ b/Nexmo.Api/ShortCode.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Nexmo.Api.Request;
 
@@ -12,6 +13,7 @@ namespace Nexmo.Api
             public string to { get; set; }
             public int? pin { get; set; }
             [JsonProperty("client-ref")]
+            [FromQuery(Name = "client-ref")]
             public string clientRef { get; set; }
         }
 
@@ -19,8 +21,10 @@ namespace Nexmo.Api
         {
             public string to { get; set; }
             [JsonProperty("status-report-req")]
+            [FromQuery(Name = "status-report-req")]
             public string statusReportReq { get; set; }
             [JsonProperty("client-ref")]
+            [FromQuery(Name = "client-ref")]
             public string clientRef { get; set; }
             public int? template { get; set; }
             public string type { get; set; }

--- a/Nexmo.Api/Voice/Call.cs
+++ b/Nexmo.Api/Voice/Call.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Nexmo.Api.Request;
 
@@ -40,6 +41,7 @@ namespace Nexmo.Api.Voice
             /// The internet media type for the audio you are streaming.Possible values are: audio/l16; rate=16000
             /// </summary>
             [JsonProperty("content-type")]
+            [FromQuery(Name = "content-type")]
             public string contentType { get; set; }
 
             /// <summary>
@@ -267,7 +269,7 @@ namespace Nexmo.Api.Voice
         /// <param name="creds">(Optional) Overridden credentials for only this request</param>
         public static CallResponse Get(string id, Credentials creds = null)
         {
-            var response = VersionedApiRequest.DoRequest(ApiRequest.GetBaseUriFor(typeof(Call), $"/v1/calls/{id}"), new {}, creds);
+            var response = VersionedApiRequest.DoRequest(ApiRequest.GetBaseUriFor(typeof(Call), $"/v1/calls/{id}"), new { }, creds);
 
             return JsonConvert.DeserializeObject<CallResponse>(response);
         }


### PR DESCRIPTION
Since the URI query deserializer ignores `JsonProperty` attribute, we might end up with missing (or default) values of properties, which have different naming in their models.
Adding the `FromQuery` attribute for properties will make the URI query deserializer correctly parse all values, when using the `FromQuery` attribute for the endpoint method parameter.

Resolves #111
