### PR TITLE
Add auto-changelog on Release

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,14 @@
+workflow "New release" {
+  on = "release"
+  resolves = ["Add Changelog"]
+}
+
+action "Add Changelog" {
+  uses = "nexmo/github-actions/nexmo-changelog@master"
+  env = {
+    CHANGELOG_CATEGORY = "Server SDK"
+    CHANGELOG_SUBCATEGORY = "dotnet"
+    CHANGELOG_RELEASE_TITLE = "nexmo-dotnet"
+  }
+  secrets = ["CHANGELOG_AUTH_TOKEN"]
+}


### PR DESCRIPTION
This PR adds a Github action which is triggered when a release is published. The action adds a new entry to the public Nexmo changelog with the contents of the release notes