### PR TITLE
adding logging extension

### DIFF
--- a/Nexmo.Api/Configuration.cs
+++ b/Nexmo.Api/Configuration.cs
@@ -1,14 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Nexmo.Api.Logging;
 using Nexmo.Api.Request;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
 
 namespace Nexmo.Api
 {
     public sealed class Configuration
     {
+        const string LOGGER_CATEGORY = "Nexmo.Api.Configuration";
         // Explicit static constructor to tell C# compiler
         // not to mark type as beforefieldinit
         static Configuration()
@@ -17,6 +19,7 @@ namespace Nexmo.Api
 
         private Configuration()
         {
+            var logger = Api.Logger.LogProvider.GetLogger(LOGGER_CATEGORY);
             var builder = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
@@ -51,15 +54,19 @@ namespace Nexmo.Api
 
             if (authCapabilities.Count == 0)
             {
+                logger.LogInformation("No authentication found via configuration. Remember to provide your own.");
+                //TODO Remove Depricated Logger call
                 Logger.Info("No authentication found via configuration. Remember to provide your own.");
             }
             else
             {
+                logger.LogInformation("Available authentication: {0}", string.Join(",", authCapabilities));
+                //TODO Remove Depricated Logger call
                 Logger.Info("Available authentication: {0}", string.Join(",", authCapabilities));
             }
         }
 
-        private static readonly ILog Logger = LogProvider.For<Configuration>();
+        private static readonly ILog Logger = Api.Logging.LogProvider.For<Configuration>();
 
         public static Configuration Instance { get; } = new Configuration();
 

--- a/Nexmo.Api/Logger/LogProvider.cs
+++ b/Nexmo.Api/Logger/LogProvider.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System;
+namespace Nexmo.Api.Logger
+{
+    public static class LogProvider
+    {
+        private static IDictionary<string, ILogger> _loggers = new Dictionary<string, ILogger>();
+        private static ILoggerFactory _loggerFactory = new LoggerFactory();
+
+        public static void SetLogFactory(ILoggerFactory factory)
+        {
+            _loggerFactory.Dispose();
+            _loggerFactory = factory;
+            _loggers.Clear();
+        }
+
+        public static ILogger GetLogger(string category)
+        {
+            if (!_loggers.ContainsKey(category))
+            {
+                _loggers[category] = _loggerFactory.CreateLogger(category);
+            }
+            return _loggers[category];
+        }
+    }
+}

--- a/Nexmo.Api/Request/ApiRequest.cs
+++ b/Nexmo.Api/Request/ApiRequest.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Nexmo.Api.Request
 {
@@ -20,6 +21,7 @@ namespace Nexmo.Api.Request
     public static class ApiRequest
     {
         private static readonly ILog Logger = LogProvider.GetLogger(typeof(ApiRequest), "Nexmo.Api.Request.ApiRequest");
+        const string LOGGER_CATEGORY = "Nexmo.Api.Request.ApiRequest";
 
         private static StringBuilder BuildQueryString(IDictionary<string, string> parameters, Credentials creds = null)
         {
@@ -146,6 +148,7 @@ namespace Nexmo.Api.Request
 
         internal static string DoRequest(Uri uri, Credentials creds)
         {
+            var logger = Api.Logger.LogProvider.GetLogger(LOGGER_CATEGORY);
             var apiKey = (creds?.ApiKey ?? Configuration.Instance.Settings["appSettings:Nexmo.api_key"])?.ToLower();
             var apiSecret = creds?.ApiSecret ?? Configuration.Instance.Settings["appSettings:Nexmo.api_secret"];
             var req = new HttpRequestMessage
@@ -166,12 +169,18 @@ namespace Nexmo.Api.Request
 
             using (LogProvider.OpenMappedContext("ApiRequest.DoRequest",uri.GetHashCode()))
             {
+                logger.LogDebug($"GET {uri}");
+
+                //TODO: Remove deprecated logger
                 Logger.Debug($"GET {uri}");
                 var sendTask = Configuration.Instance.Client.SendAsync(req);
                 sendTask.Wait();
 
                 if (!sendTask.Result.IsSuccessStatusCode)
                 {
+                    logger.LogError($"FAIL: {sendTask.Result.StatusCode}");
+
+                    //TODO: Remove deprecated logger
                     Logger.Error($"FAIL: {sendTask.Result.StatusCode}");
 
                     if (string.Compare(Configuration.Instance.Settings["appSettings:Nexmo.Api.EnsureSuccessStatusCode"],
@@ -189,6 +198,9 @@ namespace Nexmo.Api.Request
                 {
                     json = sr.ReadToEnd();
                 }
+                logger.LogDebug(json);
+                
+                //TODO: Remove Deprecated logger
                 Logger.Debug(json);
                 return json;
             }
@@ -205,6 +217,7 @@ namespace Nexmo.Api.Request
         /// <returns></returns>
         public static NexmoResponse DoRequest(string method, Uri uri, Dictionary<string, string> parameters, Credentials creds = null)
         {
+            var logger = Api.Logger.LogProvider.GetLogger(LOGGER_CATEGORY);
             var sb = new StringBuilder();
             // if parameters is null, assume that key and secret have been taken care of
             if (null != parameters)
@@ -225,12 +238,18 @@ namespace Nexmo.Api.Request
 
             using (LogProvider.OpenMappedContext("ApiRequest.DoRequest",uri.GetHashCode()))
             {
+                logger.LogDebug($"{method} {uri} {sb}");
+
+                //TODO: Remove Deprecated Logger
                 Logger.Debug($"{method} {uri} {sb}");
                 var sendTask = Configuration.Instance.Client.SendAsync(req);
                 sendTask.Wait();
 
                 if (!sendTask.Result.IsSuccessStatusCode)
                 {
+                    logger.LogError($"FAIL: {sendTask.Result.StatusCode}");
+
+                    //TODO: Remove Deprecated Logger
                     Logger.Error($"FAIL: {sendTask.Result.StatusCode}");
 
                     if (string.Compare(Configuration.Instance.Settings["appSettings:Nexmo.Api.EnsureSuccessStatusCode"],
@@ -252,6 +271,9 @@ namespace Nexmo.Api.Request
                 {
                     json = sr.ReadToEnd();
                 }
+                logger.LogDebug(json);
+
+                //TODO: Remove Deprecated Logger
                 Logger.Debug(json);
                 return new NexmoResponse
                 {
@@ -263,6 +285,7 @@ namespace Nexmo.Api.Request
 
         public static NexmoResponse DoRequest(string method, Uri uri, object requestBody, Credentials creds = null)
         {
+            var logger = Api.Logger.LogProvider.GetLogger(LOGGER_CATEGORY);
             var sb = new StringBuilder();
             var parameters = new Dictionary<string, string>();
             sb = BuildQueryString(parameters, creds);
@@ -279,6 +302,9 @@ namespace Nexmo.Api.Request
 
             using (LogProvider.OpenMappedContext("ApiRequest.DoRequest", uri.GetHashCode()))
             {
+                logger.LogDebug($"{method} {uri} {sb}");
+
+                //TODO: Remove Deprecated logger
                 Logger.Debug($"{method} {uri} {sb}");
                 var sendTask = Configuration.Instance.Client.SendAsync(req);
                 sendTask.Wait();
@@ -286,6 +312,9 @@ namespace Nexmo.Api.Request
                 if (!sendTask.Result.IsSuccessStatusCode)
                 {
                     
+                    logger.LogError($"FAIL: {sendTask.Result.StatusCode}");
+
+                    //TODO: Remove Deprecated Logger
                     Logger.Error($"FAIL: {sendTask.Result.StatusCode}");
 
                     if (string.Compare(Configuration.Instance.Settings["appSettings:Nexmo.Api.EnsureSuccessStatusCode"],
@@ -307,6 +336,9 @@ namespace Nexmo.Api.Request
                 {
                     jsonResult = sr.ReadToEnd();
                 }
+                logger.LogDebug(jsonResult);
+
+                //TODO: Remove Deprecated Logger
                 Logger.Debug(jsonResult);
                 return new NexmoResponse
                 {
@@ -318,6 +350,7 @@ namespace Nexmo.Api.Request
 
         internal static HttpResponseMessage DoRequestJwt(Uri uri, Credentials creds)
         {
+            var logger = Api.Logger.LogProvider.GetLogger(LOGGER_CATEGORY);
             var appId = creds?.ApplicationId ?? Configuration.Instance.Settings["appSettings:Nexmo.Application.Id"];
             var appKeyPath = creds?.ApplicationKey ?? Configuration.Instance.Settings["appSettings:Nexmo.Application.Key"];
 
@@ -334,12 +367,18 @@ namespace Nexmo.Api.Request
 
             using (LogProvider.OpenMappedContext("ApiRequest.DoRequestJwt", uri.GetHashCode()))
             {
+                logger.LogDebug($"GET {uri}");
+
+                //TODO: Remove Deprecated logger
                 Logger.Debug($"GET {uri}");
                 var sendTask = Configuration.Instance.Client.SendAsync(req);
                 sendTask.Wait();
 
                 if (!sendTask.Result.IsSuccessStatusCode)
                 {
+                    logger.LogError($"FAIL: {sendTask.Result.StatusCode}");
+
+                    //TODO: Remove Deprecated Logger
                     Logger.Error($"FAIL: {sendTask.Result.StatusCode}");
 
                     if (string.Compare(Configuration.Instance.Settings["appSettings:Nexmo.Api.EnsureSuccessStatusCode"],

--- a/Nexmo.Api/Request/VersionedApiRequest.cs
+++ b/Nexmo.Api/Request/VersionedApiRequest.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using System.Net.Http;
 using System.Reflection;
 using Nexmo.Api.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Nexmo.Api.Request
 {
@@ -15,6 +16,7 @@ namespace Nexmo.Api.Request
     /// </summary>
     public static class VersionedApiRequest
     {
+        private const string LOGGER_CATEGORY = "Nexmo.Api.VersionedApiRequest";
         public enum AuthType
         {
             Basic,
@@ -36,6 +38,7 @@ namespace Nexmo.Api.Request
 
         private static string DoRequest(Uri uri, AuthType authType, Credentials creds = null)
         {
+            var logger = Api.Logger.LogProvider.GetLogger(LOGGER_CATEGORY);
             var appId = creds?.ApplicationId ?? Configuration.Instance.Settings["appSettings:Nexmo.Application.Id"];
             var appKeyPath = creds?.ApplicationKey ?? Configuration.Instance.Settings["appSettings:Nexmo.Application.Key"];
             var apiKey = (creds?.ApiKey ?? Configuration.Instance.Settings["appSettings:Nexmo.api_key"])?.ToLower();
@@ -63,6 +66,9 @@ namespace Nexmo.Api.Request
 
             using (LogProvider.OpenMappedContext("VersionedApiRequest.DoRequest",uri.GetHashCode()))
             {
+                logger.LogDebug($"GET {uri}");
+
+                //TODO: Remove Deprecated Logger
                 Logger.Debug($"GET {uri}");
 
                 var sendTask = Configuration.Instance.Client.SendAsync(req);
@@ -70,6 +76,9 @@ namespace Nexmo.Api.Request
 
                 if (!sendTask.Result.IsSuccessStatusCode)
                 {
+                    logger.LogError($"FAIL: {sendTask.Result.StatusCode}");
+
+                    //TODO: Remove Deprecated Logger
                     Logger.Error($"FAIL: {sendTask.Result.StatusCode}");
 
                     if (string.Compare(Configuration.Instance.Settings["appSettings:Nexmo.Api.EnsureSuccessStatusCode"],
@@ -86,6 +95,9 @@ namespace Nexmo.Api.Request
                 {
                     json = sr.ReadToEnd();
                 }
+                logger.LogDebug(json);
+
+                //TODO: Remove Deprecated Logger
                 Logger.Debug(json);
                 return json;
             }
@@ -139,6 +151,7 @@ namespace Nexmo.Api.Request
         /// <returns></returns>
         public static NexmoResponse DoRequest(string method, Uri uri, object payload, Credentials creds = null)
         {
+            var logger = Api.Logger.LogProvider.GetLogger(LOGGER_CATEGORY);
             var appId = creds?.ApplicationId ?? Configuration.Instance.Settings["appSettings:Nexmo.Application.Id"];
             var appKeyPath = creds?.ApplicationKey ?? Configuration.Instance.Settings["appSettings:Nexmo.Application.Key"];
             var apiKey = (creds?.ApiKey ?? Configuration.Instance.Settings["appSettings:Nexmo.api_key"])?.ToLower();
@@ -172,12 +185,18 @@ namespace Nexmo.Api.Request
 
             using (LogProvider.OpenMappedContext("VersionedApiRequest.DoRequest",uri.GetHashCode()))
             {
+                logger.LogDebug($"{method} {uri} {payload}");
+
+                //TODO:Remove Deprecated Logger
                 Logger.Debug($"{method} {uri} {payload}");
                 var sendTask = Configuration.Instance.Client.SendAsync(req);
                 sendTask.Wait();
 
                 if (!sendTask.Result.IsSuccessStatusCode)
                 {
+                    logger.LogError($"FAIL: {sendTask.Result.StatusCode}");
+
+                    //TODO:Remove Deprecated Logger
                     Logger.Error($"FAIL: {sendTask.Result.StatusCode}");
 
                     if (string.Compare(Configuration.Instance.Settings["appSettings:Nexmo.Api.EnsureSuccessStatusCode"],
@@ -199,6 +218,9 @@ namespace Nexmo.Api.Request
                 {
                     json = sr.ReadToEnd();
                 }
+                logger.LogDebug(json);
+
+                //TODO: Remove Deprecated logger
                 Logger.Debug(json);
                 return new NexmoResponse
                 {


### PR DESCRIPTION
Adding Microsoft.Extensions.Logging capability - essentially allow programmers to dynamically set/change their log levels. As it stands now liblog automatically latches into whatever the chosen logging framework of the program you are using is - not necessarily a bad behavior but perhaps one that we may want to add some explicit intervention for. 

I am leaving the liblog stuff in here and marking it for removal when version 5.0 goes out as removing it would be a 'breaking change'.