### PR TITLE
Fixing malformed user agents

### DIFF
--- a/Nexmo.Api/Request/VersionedApiRequest.cs
+++ b/Nexmo.Api/Request/VersionedApiRequest.cs
@@ -96,17 +96,19 @@ namespace Nexmo.Api.Request
         {
             if (string.IsNullOrEmpty(_userAgent))
             {
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD1_6 || NETSTANDARD2_0 || NETSTANDARD2_1
                 // TODO: watch the next core release; may have functionality to make this cleaner
-                var runtimeVersion = (System.Runtime.InteropServices.RuntimeInformation.OSDescription + System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)
+                var languageVersion = (System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)
                     .Replace(" ", "")
                     .Replace("/", "")
                     .Replace(":", "")
                     .Replace(";", "")
                     .Replace("_", "")
+                    .Replace("(", "")
+                    .Replace(")", "")
                     ;
 #else
-                var runtimeVersion = System.Diagnostics.FileVersionInfo
+                var languageVersion = System.Diagnostics.FileVersionInfo
                     .GetVersionInfo(typeof(int).Assembly.Location)
                     .ProductVersion;
 #endif
@@ -116,7 +118,7 @@ namespace Nexmo.Api.Request
                     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                     .InformationalVersion;
 
-                _userAgent = $"nexmo-dotnet/{libraryVersion} dotnet/{runtimeVersion}";
+                _userAgent = $"nexmo-dotnet/{libraryVersion} dotnet/{languageVersion}";
 
                 var appVersion = creds?.AppUserAgent ?? Configuration.Instance.Settings["appSettings:Nexmo.UserAgent"];
                 if (!string.IsNullOrWhiteSpace(appVersion))


### PR DESCRIPTION
Bringing UserAgent in line with spec - also removing any parentheses from the framework description as the .NET Http library will object to them without spaces this will fix #145 