### PR TITLE
Adding Psd2 functionality

### DIFF
--- a/Nexmo.Api.Test.Unit/VerifyTest.cs
+++ b/Nexmo.Api.Test.Unit/VerifyTest.cs
@@ -25,7 +25,7 @@ namespace Nexmo.Api.Test.Unit
             VerifyRequest request = new VerifyRequest { Number= "447700900000", Brand="Acme Inc"};
             if (kitchenSink)
             {
-                expectedRequestContent = $"number=447700900000&country=GB&brand={HttpUtility.UrlEncode("Acme Inc")}&sender_id=ACME&code_length=4&lg=en-us&pin_expiry=240&next_event_wait=60&workflow_id=1&api_key={ApiKey}&api_secret={ApiSecret}&";
+                expectedRequestContent = $"brand={HttpUtility.UrlEncode("Acme Inc")}&sender_id=ACME&workflow_id=1&number=447700900000&country=GB&code_length=4&lg=en-us&pin_expiry=240&next_event_wait=60&api_key={ApiKey}&api_secret={ApiSecret}&";
                 request.Country = "GB";
                 request.SenderId = "ACME";
                 request.CodeLength = 4;
@@ -36,7 +36,7 @@ namespace Nexmo.Api.Test.Unit
             }
             else 
             {
-                expectedRequestContent = $"number=447700900000&brand={HttpUtility.UrlEncode("Acme Inc")}&api_key={ApiKey}&api_secret={ApiSecret}&";
+                expectedRequestContent = $"brand={HttpUtility.UrlEncode("Acme Inc")}&number=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
             }
             Setup(expectedUri, expectedResponse, expectedRequestContent);
             var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
@@ -225,6 +225,51 @@ namespace Nexmo.Api.Test.Unit
                 Assert.Equal("4", ex.Response.Status);
                 Assert.Equal("invalid credentials", ex.Response.ErrorText);
             }            
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void Psd2Verification(bool passCreds, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""request_id"": ""abcdef0123456789abcdef0123456789"",
+              ""status"": ""0""
+            }";
+            var expectedUri = $"{ApiUrl}/psd2/json";
+
+            string expectedRequestContent;
+            Psd2Request request = new Psd2Request { Number = "447700900000", Payee = "Acme Inc", Amount = 4.8 };
+            if (kitchenSink)
+            {
+                expectedRequestContent = $"payee={HttpUtility.UrlEncode("Acme Inc")}&amount=4.8&workflow_id=1&number=447700900000&country=GB&code_length=4&lg=en-us&pin_expiry=240&next_event_wait=60&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request.Country = "GB";
+                request.CodeLength = 4;
+                request.Lg = "en-us";
+                request.PinExpiry = 240;
+                request.NextEventWait = 60;
+                request.WorkflowId = Psd2Request.Workflow.SMS_TTS_TTS;
+            }
+            else
+            {
+                expectedRequestContent = $"payee={HttpUtility.UrlEncode("Acme Inc")}&amount=4.8&number=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+            }
+
+            Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new NexmoClient(creds);
+            VerifyResponse response;
+            if (passCreds)
+            {
+                response = client.VerifyClient.VerifyRequestWithPSD2(request, creds);
+            }
+            else
+            {
+                response = client.VerifyClient.VerifyRequestWithPSD2(request);
+            }
+
+            Assert.Equal("abcdef0123456789abcdef0123456789", response.RequestId);
+            Assert.Equal("0", response.Status);
         }
     }
 }

--- a/Nexmo.Api.Test.Unit/VerifyTest.cs
+++ b/Nexmo.Api.Test.Unit/VerifyTest.cs
@@ -236,7 +236,7 @@ namespace Nexmo.Api.Test.Unit
               ""request_id"": ""abcdef0123456789abcdef0123456789"",
               ""status"": ""0""
             }";
-            var expectedUri = $"{ApiUrl}/psd2/json";
+            var expectedUri = $"{ApiUrl}/verify/psd2/json";
 
             string expectedRequestContent;
             Psd2Request request = new Psd2Request { Number = "447700900000", Payee = "Acme Inc", Amount = 4.8 };

--- a/Nexmo.Api/Nexmo.Api.csproj
+++ b/Nexmo.Api/Nexmo.Api.csproj
@@ -15,11 +15,11 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>5.0.0</Version>
+    <Version>5.1.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Nexmo/nexmo-dotnet</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/Nexmo/nexmo-dotnet/releases/tag/v5.0.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Nexmo/nexmo-dotnet/releases/tag/v5.1.0</PackageReleaseNotes>
     <PackageTags>SMS voice telephony phone nexmo</PackageTags>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <NoWarn>1701;1702;1591;1572;1573;0618</NoWarn>

--- a/Nexmo.Api/Nexmo.Api.nuspec
+++ b/Nexmo.Api/Nexmo.Api.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Nexmo.Csharp.Client</id>
-    <version>5.0.0</version>
+    <version>5.1.0</version>
     <title>Nexmo API Client</title>
     <authors>Nexmo</authors>
     <owners>Nexmo</owners>
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Official C#/.NET wrapper for the Nexmo API</description>
     <releaseNotes>
-https://github.com/Nexmo/nexmo-dotnet/releases/tag/v5.0.0
+https://github.com/Nexmo/nexmo-dotnet/releases/tag/v5.1.0
     </releaseNotes>
     <copyright>© Nexmo 2020</copyright>
     <tags>SMS voice telephony phone nexmo vonage</tags>

--- a/Nexmo.Api/Properties/AssemblyInfo.cs
+++ b/Nexmo.Api/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyVersion("5.1.0.0")]
+[assembly: AssemblyFileVersion("5.1.0.0")]

--- a/Nexmo.Api/Verify/IVerifyClient.cs
+++ b/Nexmo.Api/Verify/IVerifyClient.cs
@@ -34,6 +34,17 @@ namespace Nexmo.Api.Verify
         /// <param name="request"></param>
         /// <param name="creds"></param>
         /// <returns></returns>
-        VerifyControlResponse VerifyControl(VerifyControlRequest request, Credentials creds = null);        
+        VerifyControlResponse VerifyControl(VerifyControlRequest request, Credentials creds = null);
+
+        /// <summary>
+        /// Use Verify request to generate and send a PIN to your user to authorize a payment: 
+        /// 1. Create a request to send a verification code to your user. 
+        /// 2. Check the status field in the response to ensure that your request was successful (zero is success). 
+        /// 3. Use the request_id field in the response for the Verify check.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="creds"></param>
+        /// <returns></returns>
+        VerifyResponse VerifyRequestWithPSD2(Psd2Request request, Credentials creds = null);
     }
 }

--- a/Nexmo.Api/Verify/Psd2Request.cs
+++ b/Nexmo.Api/Verify/Psd2Request.cs
@@ -1,0 +1,39 @@
+﻿using Newtonsoft.Json;
+
+namespace Nexmo.Api.Verify
+{
+    public class Psd2Request : VerifyRequestBase
+    {
+        public enum Workflow
+        {
+            SMS_TTS_TTS = 1,
+            SMS_SMS_TTS = 1,
+            TTS_TTS = 3,
+            SMS_SMS = 4,
+            SMS_TTS = 5,
+            SMS = 6,
+            TTS = 7
+        }
+
+        /// <summary>
+        /// An alphanumeric string to indicate to the user the 
+        /// name of the recipient that they are confirming a payment to.
+        /// </summary>
+        [JsonProperty("payee")]
+        public string Payee { get; set; }
+
+        /// <summary>
+        /// The Decimal amount of the payment to be confirmed, in Euros
+        /// </summary>
+        [JsonProperty("amount")]
+        public double? Amount { get; set; }
+
+        /// <summary>
+        /// Selects the predefined sequence of SMS and TTS (Text To Speech) actions to use in order to convey the PIN to your user. 
+        /// For example, an id of 1 identifies the workflow SMS - TTS - TTS. 
+        /// For a list of all workflows and their associated ids, please visit the developer portal.
+        /// </summary>
+        [JsonProperty("workflow_id")]
+        public Workflow? WorkflowId { get; set; }
+    }
+}

--- a/Nexmo.Api/Verify/VerifyClient.cs
+++ b/Nexmo.Api/Verify/VerifyClient.cs
@@ -56,7 +56,7 @@ namespace Nexmo.Api.Verify
         public VerifyResponse VerifyRequestWithPSD2(Psd2Request request, Credentials creds)
         {
             var response = ApiRequest.DoPostRequestUrlContentFromObject<VerifyResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/psd2/json"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/verify/psd2/json"),
                 request,
                 creds ?? Credentials
             );

--- a/Nexmo.Api/Verify/VerifyClient.cs
+++ b/Nexmo.Api/Verify/VerifyClient.cs
@@ -53,6 +53,17 @@ namespace Nexmo.Api.Verify
             return response;
         }
 
+        public VerifyResponse VerifyRequestWithPSD2(Psd2Request request, Credentials creds)
+        {
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<VerifyResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/psd2/json"),
+                request,
+                creds ?? Credentials
+            );
+            ValidateVerifyResponse(response);
+            return response;
+        }
+
         public void ValidateVerifyResponse(VerifyResponseBase response)
         {
             if (response.Status != "0")

--- a/Nexmo.Api/Verify/VerifyRequest.cs
+++ b/Nexmo.Api/Verify/VerifyRequest.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Nexmo.Api.Verify
 {
-    public class VerifyRequest
+    public class VerifyRequest : VerifyRequestBase
     {
         public enum Workflow
         {
@@ -14,17 +14,6 @@ namespace Nexmo.Api.Verify
             SMS=6,
             TTS=7
         }
-        /// <summary>
-        /// The mobile or landline phone number to verify. Unless you are setting country explicitly, this number must be in E.164 format.
-        /// </summary>
-        [JsonProperty("number")]
-        public string Number { get; set; }
-
-        /// <summary>
-        /// If you do not provide number in international format or you are not sure if number is correctly formatted, specify the two-character country code in country. Verify will then format the number for you.
-        /// </summary>
-        [JsonProperty("country")]
-        public string Country { get; set; }
 
         /// <summary>
         /// An 18-character alphanumeric string you can use to personalize the verification request SMS body, to help users identify your company or application name. For example: "Your Acme Inc PIN is ..."
@@ -40,42 +29,12 @@ namespace Nexmo.Api.Verify
         public string SenderId { get; set; }
 
         /// <summary>
-        /// The length of the verification code. Must be 4 or 6
-        /// </summary>
-        [JsonProperty("code_length")]
-        public int CodeLength { get; set; }
-
-        /// <summary>
-        /// By default, the SMS or text-to-speech (TTS) message is generated in the locale that matches the number. 
-        /// For example, the text message or TTS message for a 33* number is sent in French. 
-        /// Use this parameter to explicitly control the language used for the Verify request. 
-        /// A list of languages is available: https://developer.nexmo.com/verify/guides/verify-languages
-        /// </summary>
-        [JsonProperty("lg")]
-        public string Lg { get; set; }
-
-        /// <summary>
-        /// How long the generated verification code is valid for, in seconds. 
-        /// When you specify both pin_expiry and next_event_wait then pin_expiry must be an integer 
-        /// multiple of next_event_wait otherwise pin_expiry is defaulted to equal next_event_wait. 
-        /// See changing the event timings: https://developer.nexmo.com/verify/guides/changing-default-timings.
-        /// </summary>
-        [JsonProperty("pin_expiry")]
-        public int PinExpiry { get; set; }
-
-        /// <summary>
-        /// Specifies the wait time in seconds between attempts to deliver the verification code.
-        /// Must be between 60 and 900
-        /// </summary>
-        [JsonProperty("next_event_wait")]
-        public int NextEventWait { get; set; }
-
-        /// <summary>
         /// Selects the predefined sequence of SMS and TTS (Text To Speech) actions to use in order to convey the PIN to your user. 
         /// For example, an id of 1 identifies the workflow SMS - TTS - TTS. 
         /// For a list of all workflows and their associated ids, please visit the developer portal.
         /// </summary>
         [JsonProperty("workflow_id")]
         public Workflow? WorkflowId { get; set; }
+
     }
 }

--- a/Nexmo.Api/Verify/VerifyRequestBase.cs
+++ b/Nexmo.Api/Verify/VerifyRequestBase.cs
@@ -1,0 +1,50 @@
+﻿using Newtonsoft.Json;
+
+namespace Nexmo.Api.Verify
+{
+    public class VerifyRequestBase
+    {
+        /// <summary>
+        /// The mobile or landline phone number to verify. Unless you are setting country explicitly, this number must be in E.164 format.
+        /// </summary>
+        [JsonProperty("number")]
+        public string Number { get; set; }
+
+        /// <summary>
+        /// If you do not provide number in international format or you are not sure if number is correctly formatted, specify the two-character country code in country. Verify will then format the number for you.
+        /// </summary>
+        [JsonProperty("country")]
+        public string Country { get; set; }                
+
+        /// <summary>
+        /// The length of the verification code. Must be 4 or 6
+        /// </summary>
+        [JsonProperty("code_length")]
+        public int CodeLength { get; set; }
+
+        /// <summary>
+        /// By default, the SMS or text-to-speech (TTS) message is generated in the locale that matches the number. 
+        /// For example, the text message or TTS message for a 33* number is sent in French. 
+        /// Use this parameter to explicitly control the language used for the Verify request. 
+        /// A list of languages is available: https://developer.nexmo.com/verify/guides/verify-languages
+        /// </summary>
+        [JsonProperty("lg")]
+        public string Lg { get; set; }
+
+        /// <summary>
+        /// How long the generated verification code is valid for, in seconds. 
+        /// When you specify both pin_expiry and next_event_wait then pin_expiry must be an integer 
+        /// multiple of next_event_wait otherwise pin_expiry is defaulted to equal next_event_wait. 
+        /// See changing the event timings: https://developer.nexmo.com/verify/guides/changing-default-timings.
+        /// </summary>
+        [JsonProperty("pin_expiry")]
+        public int PinExpiry { get; set; }
+
+        /// <summary>
+        /// Specifies the wait time in seconds between attempts to deliver the verification code.
+        /// Must be between 60 and 900
+        /// </summary>
+        [JsonProperty("next_event_wait")]
+        public int NextEventWait { get; set; }        
+    }
+}


### PR DESCRIPTION
Abstracted some of the overlap between regular verify and psd2 into a base class, added new psd2 functionality.

As I abstracted some of data struct into a base class I needed to move around some of the fields in the URL form for the regular Verify request's unit tests.